### PR TITLE
Improve access to transformed variants

### DIFF
--- a/lib/image_wrangler/transformers/transformer.rb
+++ b/lib/image_wrangler/transformers/transformer.rb
@@ -43,6 +43,10 @@ module ImageWrangler
         source_image
       end
 
+      def components
+        @component_list
+      end
+
       def errors
         @errors ||= @options[:errors]
       end

--- a/test/image_wrangler/transformers/transformer_test.rb
+++ b/test/image_wrangler/transformers/transformer_test.rb
@@ -49,14 +49,14 @@ module ImageWrangler
         assert transformer.valid?
         assert transformer.process
 
-        render_one = ImageWrangler::Image.new(component_list[0][:filepath])
+        render_one = transformer.components[0]
         assert_equal 200, render_one.height
 
         # Source for first render is our main image ^
         source_image = transformer.components[0].source_image
         assert_equal image.filepath, source_image.filepath
 
-        render_two = ImageWrangler::Image.new(component_list[1][:filepath])
+        render_two = transformer.components[1]
         assert_equal 100, render_two.height
 
         # Source for second render is the previously rendered variant ^

--- a/test/image_wrangler/transformers/transformer_test.rb
+++ b/test/image_wrangler/transformers/transformer_test.rb
@@ -53,14 +53,14 @@ module ImageWrangler
         assert_equal 200, render_one.height
 
         # Source for first render is our main image ^
-        source_image = transformer.component_list.variants[0].source_image
+        source_image = transformer.components[0].source_image
         assert_equal image.filepath, source_image.filepath
 
         render_two = ImageWrangler::Image.new(component_list[1][:filepath])
         assert_equal 100, render_two.height
 
         # Source for second render is the previously rendered variant ^
-        source_image = transformer.component_list.variants[1].source_image
+        source_image = transformer.components[1].source_image
         assert_equal render_one.filepath, source_image.filepath
       end
       # rubocop:enable Metrics/MethodLength


### PR DESCRIPTION
This enables access to transformed variants and associated metadata (limited to height, width, mtime etc) following successful processing:

```
transformer = image.transformer(component_list, { cascade: true })
transformer.process if transformer.valid?

render_one = transformer.components[0]
render_one.height #=> 200
render_one.mime_type #=> 'image/jpeg'
```

