### PR TITLE
Wrap Magick exceptions, using ruby .cause to access nested errors

### DIFF
--- a/lib/image_wrangler/handlers/mini_magick_handler.rb
+++ b/lib/image_wrangler/handlers/mini_magick_handler.rb
@@ -267,7 +267,8 @@ module ImageWrangler
           raise ImageWrangler::Error, 'empty file'
         end
 
-        raise
+        # In calling code, use err.cause to access nested exception
+        raise ImageWrangler::Error, 'MiniMagick error'
       end
 
       def handle_mini_magick_invalid(error)
@@ -285,8 +286,6 @@ module ImageWrangler
         MiniMagick.configure do |config|
           config.quiet_warnings = options.fetch(:quiet_warnings)
         end
-
-        # @errors = options.fetch(:errors)
       end
     end
     # rubocop:enable Metrics/ClassLength

--- a/lib/mini_magick_extensions/format_families.rb
+++ b/lib/mini_magick_extensions/format_families.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 module MiniMagick
-  RASTER_FORMATS = %w[BMP JPEG JPF PAM PNG WEBP GIF HEIF TIFF].freeze
+  RASTER_FORMATS = %w[BMP JPEG JPF JP2 PAM PNG WEBP GIF HEIF TIFF].freeze
   VECTOR_FORMATS = %w[PDF PS EPT EPS SVG].freeze
   POSTSCRIPT_FORMATS = %w[PDF EPT EPS PS].freeze
 

--- a/test/fixtures/raster/jpeg_2000_as_jpg.jpg
+++ b/test/fixtures/raster/jpeg_2000_as_jpg.jpg
@@ -1,0 +1,1 @@
+./valid_jpeg_2000.jp2

--- a/test/fixtures/raster/valid_jpeg_2000
+++ b/test/fixtures/raster/valid_jpeg_2000
@@ -1,0 +1,1 @@
+./valid_jpeg_2000.jp2


### PR DESCRIPTION
Adds handling for JP2/Jpeg2000 files which are not cleanly loaded using
this version of IM and openjpg2