### PR TITLE
Improve reliability when scaling to pixel area

### DIFF
--- a/lib/image_wrangler/dimensions.rb
+++ b/lib/image_wrangler/dimensions.rb
@@ -17,8 +17,12 @@ module ImageWrangler
       [width, height]
     end
 
+    def max
+      to_a.max
+    end
+
     def to_h
-      {width: width, height: height, area: area}
+      {width: width, height: height, area: area, max: max}
     end
 
     def to_s

--- a/lib/image_wrangler/scaling_helper.rb
+++ b/lib/image_wrangler/scaling_helper.rb
@@ -3,12 +3,12 @@
 module ImageWrangler
   # Methods for scaling calculations
   module ScalingHelper
-    def downscale_to_pixelarea(target_pixelarea, filepath)
+    def downscale_to_pixelarea(target_pixel_area, filepath)
       # Only raster images
       return false unless raster?
 
-      scf = scaling_factor(target_pixelarea)
-      max_dim = [(scf * width).to_i, (scf * height).to_i].max
+      new_dimensions = dimensions_for_target_pixel_area(target_pixel_area)
+      max_dim = new_dimensions.max
 
       transform = {
         filepath: filepath,
@@ -34,6 +34,11 @@ module ImageWrangler
       current_area = w * h
       return 1.0 if current_area == target_pixel_area
 
+      scaling_factor_two(target_pixel_area, current_area)
+    end
+
+    # Original, unreliable scaling
+    def scaling_factor_one(target_pixel_area, current_area)
       downscaling = target_pixel_area < current_area
 
       # Unless downscaling, we need to meet or exceed the required target area.
@@ -42,14 +47,27 @@ module ImageWrangler
       downscaling ? scf : scf.round(4)
     end
 
+    # Simplest method, no rounding
+    def scaling_factor_two(target_pixel_area, current_area)
+      Math.sqrt(target_pixel_area / current_area.to_f) # no rounding
+    end
+
     def dimensions_for_fixed_side(fixed_side)
       sf = fixed_side.to_f / [width, height].max
       ImageWrangler::Dimensions.new((width * sf).ceil, (height * sf).ceil)
     end
 
-    def dimensions_for_target_pixel_area(target_pixel_area)
-      scf = scaling_factor(target_pixel_area, width, height)
-      ImageWrangler::Dimensions.new((width * scf).ceil, (height * scf).ceil)
+    # If downscaling, we need to be <= target, so use .to_i when rounding
+    # If upscaling, we need to be >= target, so use .ceil when rounding
+    def dimensions_for_target_pixel_area(target_pixel_area, w = width, h = height)
+      current_area = w * h
+      return ImageWrangler::Dimensions.new(w, h) if current_area == target_pixel_area
+
+      downscaling = current_area > target_pixel_area
+      scf = scaling_factor_two(target_pixel_area, current_area)
+
+      rounding = downscaling ? :to_i : :ceil
+      ImageWrangler::Dimensions.new((w * scf).send(rounding), (h * scf).send(rounding))
     end
 
     def pixel_area_for_fixed_side(fixed_side)

--- a/test/image_wrangler/dimensions_test.rb
+++ b/test/image_wrangler/dimensions_test.rb
@@ -11,7 +11,8 @@ module ImageWrangler
       dims = ImageWrangler::Dimensions.new(990, 503)
       assert_equal "990x503", dims.to_s
       assert_equal([990, 503], dims.to_a)
-      assert_equal({width: 990, height: 503, area: 497970}, dims.to_h)
+      assert_equal(4, dims.to_h.size)
+      assert_equal(990, dims.max)
     end
   end
 end

--- a/test/image_wrangler/scaling_helper_test.rb
+++ b/test/image_wrangler/scaling_helper_test.rb
@@ -23,61 +23,51 @@ module ImageWrangler
       assert(new_im.pixelarea <= target_pixelarea)
     end
 
-    def test_upscaling_factor
-      subject = DummyImage.new(nil, nil)
-      target_px_area = 5_230_000
-      assert_equal 3.2413, subject.scaling_factor(target_px_area, 990, 503)
-    end
-
-    # No rounding when downscaling as we want to be as close as possible
-    def test_downscaling_factor
-      subject = DummyImage.new(nil, nil)
-      target_px_area = 1_168_561 # 1080x1080
-      assert_equal 0.3120578204969927, subject.scaling_factor(target_px_area, 3000, 4000)
-    end
-
     def test_pixel_area_for_fixed_side
       subject = DummyImage.new(4048, 3032)
       assert_equal 43200, subject.pixel_area_for_fixed_side(240)
     end
 
-    def test_upscaling_factor_volume
-      skip("Enable when volume testing")
+    def test_dimensions_for_target_pixel_area_upscaling_volume
+      skip("enable when volume testing")
       subject = DummyImage.new(nil, nil)
       target_px_area = 5_230_000
 
       dims = (100..2286)
       dims.each do |w|
         dims.each do |h|
-          scf = subject.scaling_factor(target_px_area, w, h)
-          new_w = (w * scf).ceil
-          new_h = (h * scf).ceil
-          assert((new_w * new_h) >= target_px_area, "#{w} x #{h} @ #{scf} failed")
+          result = subject.dimensions_for_target_pixel_area(target_px_area, w, h)
+          assert(result.area >= target_px_area, "#{w} x #{h} -> #{result.area}")
         end
       end
     end
 
-    def test_downscaling_factor_volume
-      skip("Enable when volume testing")
+    def test_dimensions_for_target_pixel_area_downscaling_volume
+      skip("enable when volume testing")
       subject = DummyImage.new(nil, nil)
       target_px_area = 1_168_561
 
       dims = (2000..5000)
       dims.each do |w|
         dims.each do |h|
-          scf = subject.scaling_factor(target_px_area, w, h)
-          new_w = (w * scf).ceil
-          new_h = (h * scf).ceil
-          assert((new_w * new_h) >= target_px_area, "#{w} x #{h} @ #{scf} failed")
+          result = subject.dimensions_for_target_pixel_area(target_px_area, w, h)
+          assert(result.area <= target_px_area, "#{w} x #{h} -> #{result.area}")
         end
       end
     end
 
-    def test_dimensions_for_target_pixel_area
+    def test_dimensions_for_target_pixel_area_upscaling
       subject = DummyImage.new(990, 503)
       result = subject.dimensions_for_target_pixel_area(5_230_000)
       assert_equal(3209, result.width)
       assert_equal(1631, result.height)
+    end
+
+    def test_dimensions_for_target_pixel_area_downscaling
+      subject = DummyImage.new(21002, 12504)
+      result = subject.dimensions_for_target_pixel_area(256_000_000)
+      assert_equal(20736, result.width)
+      assert_equal(12345, result.height)
     end
 
     def test_dimensions_for_fixed_side


### PR DESCRIPTION
Some scaling geometries exceed target pixel area - this change should ensure downscaling <= target_area and upscaling >= target_area